### PR TITLE
feature/add-ddl: add ddl file of current db

### DIFF
--- a/db/db.sql
+++ b/db/db.sql
@@ -1,0 +1,40 @@
+drop table if exists patient_location;
+create table `patient_location` (
+    `id` int(10) NOT NULL AUTO_INCREMENT,
+    `location` varchar(10) NOT NULL UNIQUE,
+    `sum` int(10) NOT NULL,
+    primary key (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+drop table if exists patient_location;
+create table `patient_by_date` (
+    `id` int(10) NOT NULL AUTO_INCREMENT,
+    `date` varchar(10) NOT NULL UNIQUE,
+    `confirmed` int(10) NOT NULL,
+    `recovered` int(10) NOT NULL,
+    `dead` int(10) NOT NULL,
+    `critical` int(10) NOT NULL,
+    `tested` int(10) NOT NULL,
+    primary key (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+drop table if exists news;
+create table `news` (
+    `id` int(10) NOT NULL AUTO_INCREMENT,
+    `title` varchar(10) NOT NULL UNIQUE,
+    `link` varchar(10) NOT NULL UNIQUE,
+    `url` varchar(10) NOT NULL UNIQUE,
+    `updated_time` varchar(10) NOT NULL,
+    `passed_day` int(10) NOT NULL,
+    `passed_minutes` int(10) NOT NULL,
+    `passed_hour` int(10) NOT NULL,
+    `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    primary key (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+drop table if exists last_update_time;
+create table `last_update_time`(
+    `id` int(10) NOT NULL AUTO_INCREMENT,
+    `patient_data_update_time` varchar(10) NOT NULL,
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## added
- ddl追加

## problem
- 現状ddl元にdb deployする機能の追加が必要
- `last_update_time`は削除予定、醜い
- `patient_by_date`にupdated_atを追加して、毎回そこの時間を元に計算
- `news`もgo-cacheに変えて、dbから消す予定。